### PR TITLE
feature: ProjectWorker

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
-    "adm-zip": "^0.4.14",
     "amqplib": "^0.5.2",
     "newrelic": "^6.5.0",
     "raven": "^2.6.4",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
+    "adm-zip": "^0.4.14",
     "amqplib": "^0.5.2",
     "newrelic": "^6.5.0",
     "raven": "^2.6.4",

--- a/src/taskmaster.ts
+++ b/src/taskmaster.ts
@@ -4,7 +4,9 @@ import * as amqp from 'amqplib/callback_api'
 import {Connection} from 'amqplib/callback_api'
 import { execute } from './tasks'
 import config = require('../config.js')
-import {SubmitJob, RunJob, ProjectJob} from 'tasks/job';
+import {SubmitJob} from './tasks/jobs/submission';
+import {ProjectJob} from './tasks/jobs/project';
+import {RunJob} from './tasks/jobs/run';
 import { mkdir } from 'shelljs'
 
 // =============== Setup Raven

--- a/src/taskmaster.ts
+++ b/src/taskmaster.ts
@@ -4,7 +4,7 @@ import * as amqp from 'amqplib/callback_api'
 import {Connection} from 'amqplib/callback_api'
 import { execute } from './tasks'
 import config = require('../config.js')
-import { SubmitJob, RunJob } from 'tasks/job';
+import {SubmitJob, RunJob, ProjectJob} from 'tasks/job';
 import { mkdir } from 'shelljs'
 
 // =============== Setup Raven
@@ -40,6 +40,9 @@ amqp.connect(`amqp://${config.AMQP.USER}:${config.AMQP.PASS}@${config.AMQP.HOST}
             break
           case 'run':
             job = new RunJob(payload)
+            break
+          case 'project':
+            job = new ProjectJob(payload)
             break
           default:
             throw new Error("Scenario not declared")

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -1,14 +1,16 @@
-import { Result, RunResult, SubmissionResult } from 'types/result'
+import { Result, RunResult, SubmissionResult, ProjectResult } from 'types/result'
 import config = require('../../config.js')
 import {exec, mkdir, rm} from 'shelljs'
 import * as path from 'path'
 
 import RunScenario from './scenarios/run'
 import SubmissionScenario from './scenarios/submission'
-import { RunJob, SubmitJob, Job } from "./job";
+import ProjectScenario from './scenarios/project';
+import { RunJob, SubmitJob, ProjectJob, Job } from "./job";
 
 export function execute(job: RunJob): Promise<RunResult>
 export function execute(job: SubmitJob): Promise<SubmissionResult>
+export function execute(job: ProjectJob): Promise<ProjectResult>
 export async function execute (job: Job) {
   // Create RUNBOX  
   const currentJobDir = path.join(config.RUNBOX.DIR, job.id.toString())
@@ -19,6 +21,8 @@ export async function execute (job: Job) {
     scenario = new RunScenario()
   } else if (job instanceof SubmitJob) {
     scenario = new SubmissionScenario()
+  } else if (job instanceof ProjectJob) {
+    scenario = new ProjectScenario()
   }
 
   // Setup RUNBOX
@@ -30,7 +34,7 @@ export async function execute (job: Job) {
   // Get result
   const result = await scenario.result(currentJobDir, job)
 
-  rm('-rf', currentJobDir)
+  // rm('-rf', currentJobDir)
 
   return result
 }

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -34,7 +34,7 @@ export async function execute (job: Job) {
   // Get result
   const result = await scenario.result(currentJobDir, job)
 
-  // rm('-rf', currentJobDir)
+  rm('-rf', currentJobDir)
 
   return result
 }

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -5,8 +5,11 @@ import * as path from 'path'
 
 import RunScenario from './scenarios/run'
 import SubmissionScenario from './scenarios/submission'
-import ProjectScenario from './scenarios/project';
-import { RunJob, SubmitJob, ProjectJob, Job } from "./job";
+import ProjectScenario from './scenarios/project'
+import {Job } from './job'
+import {RunJob} from './jobs/run'
+import {SubmitJob} from './jobs/submission';
+import {ProjectJob} from './jobs/project';
 
 export function execute(job: RunJob): Promise<RunResult>
 export function execute(job: SubmitJob): Promise<SubmissionResult>

--- a/src/tasks/job.ts
+++ b/src/tasks/job.ts
@@ -18,7 +18,8 @@ interface SubmitJobConstructorOpts extends JobConstructorOpts {
 }
 
 interface ProjectConstructorOpts extends JobConstructorOpts {
-  problem: string
+  problem: string,
+  submissionDirs: string
 }
 
 export class Job { 
@@ -57,9 +58,11 @@ export class SubmitJob extends Job {
 
 export class ProjectJob extends Job {
   problem: string
+  submissionDirs: string
 
-  constructor({ id, source, lang, timelimit, scenario, problem}: ProjectConstructorOpts) {
+  constructor({ id, source, lang, timelimit, scenario, problem, submissionDirs}: ProjectConstructorOpts) {
     super({ id, source, lang, timelimit, scenario})
     this.problem = problem
+    this.submissionDirs = submissionDirs
   }
 }

--- a/src/tasks/job.ts
+++ b/src/tasks/job.ts
@@ -1,26 +1,10 @@
-interface JobConstructorOpts {
+export interface JobConstructorOpts {
   id: number
   source: string
   lang: string
   scenario: "run" | "submit" | "project"
   timelimit?: number
 } 
-interface RunJobConstructorOpts extends JobConstructorOpts {
-  stdin: string
-}
-interface TestcaseOpts {
-  id: number, 
-  input: string, 
-  output: string
-}
-interface SubmitJobConstructorOpts extends JobConstructorOpts {
-  testcases: Array<TestcaseOpts>
-}
-
-interface ProjectConstructorOpts extends JobConstructorOpts {
-  problem: string,
-  submissionDirs: string
-}
 
 export class Job { 
   id: number
@@ -38,31 +22,4 @@ export class Job {
   }
 }
 
-export class RunJob extends Job {
-  stdin: string
 
-  constructor({ id, source, lang, timelimit, scenario, stdin }: RunJobConstructorOpts) {
-    super({id, source, lang, timelimit, scenario})
-    this.stdin = stdin
-  }
-}
-
-export class SubmitJob extends Job {
-  testcases: Array<TestcaseOpts>
-
-  constructor({ id, source, lang, timelimit, scenario, testcases }: SubmitJobConstructorOpts) {
-    super({id, source, lang, timelimit, scenario})
-    this.testcases = testcases
-  }
-}
-
-export class ProjectJob extends Job {
-  problem: string
-  submissionDirs: string
-
-  constructor({ id, source, lang, timelimit, scenario, problem, submissionDirs}: ProjectConstructorOpts) {
-    super({ id, source, lang, timelimit, scenario})
-    this.problem = problem
-    this.submissionDirs = submissionDirs
-  }
-}

--- a/src/tasks/jobs/project.ts
+++ b/src/tasks/jobs/project.ts
@@ -1,0 +1,16 @@
+import {Job, JobConstructorOpts} from '../job';
+
+interface ProjectConstructorOpts extends JobConstructorOpts {
+  problem: string,
+  submissionDirs: string
+}
+export class ProjectJob extends Job {
+  problem: string
+  submissionDirs: string
+
+  constructor({ id, source, lang, timelimit, scenario, problem, submissionDirs}: ProjectConstructorOpts) {
+    super({ id, source, lang, timelimit, scenario})
+    this.problem = problem
+    this.submissionDirs = submissionDirs
+  }
+}

--- a/src/tasks/jobs/run.ts
+++ b/src/tasks/jobs/run.ts
@@ -1,0 +1,14 @@
+import {Job, JobConstructorOpts} from '../job';
+
+interface RunJobConstructorOpts extends JobConstructorOpts {
+  stdin: string
+}
+
+export class RunJob extends Job {
+  stdin: string
+
+  constructor({ id, source, lang, timelimit, scenario, stdin }: RunJobConstructorOpts) {
+    super({id, source, lang, timelimit, scenario})
+    this.stdin = stdin
+  }
+}

--- a/src/tasks/jobs/submission.ts
+++ b/src/tasks/jobs/submission.ts
@@ -1,0 +1,20 @@
+import {Job, JobConstructorOpts} from '../job';
+
+interface TestcaseOpts {
+  id: number,
+  input: string,
+  output: string
+}
+
+interface SubmitJobConstructorOpts extends JobConstructorOpts {
+  testcases: Array<TestcaseOpts>
+}
+
+export class SubmitJob extends Job {
+  testcases: Array<TestcaseOpts>
+
+  constructor({ id, source, lang, timelimit, scenario, testcases }: SubmitJobConstructorOpts) {
+    super({id, source, lang, timelimit, scenario})
+    this.testcases = testcases
+  }
+}

--- a/src/tasks/scenarios/project.ts
+++ b/src/tasks/scenarios/project.ts
@@ -1,20 +1,32 @@
 import config = require('../../../config.js')
 import {cat, exec, mkdir, rm, touch, head} from 'shelljs'
-import { ProjectJob } from 'tasks/job'
+import {ProjectJob} from 'tasks/job'
 import { ProjectResult } from 'types/result'
 import * as path from 'path'
-import * as fs from 'fs'
 import { Scenario } from 'tasks/scenario'
 import { download } from 'utils/request'
 
 export default class ProjectScenario extends Scenario {
   async setup(currentJobDir: string, job: ProjectJob) {
-    // TODO
-    const problemDir = path.join(currentJobDir, job.problem)
-    await download(job.problem, problemDir)
+    const problemDir = path.join(currentJobDir, 'problem')
+    mkdir('-p', problemDir)
+    await download(job.problem, path.join(problemDir, 'problem'))
 
-    const solutionDir = path.join(currentJobDir, job.source)
-    await download(job.problem, solutionDir)
+    const solutionDir = path.join(currentJobDir, 'solution')
+    mkdir('-p', solutionDir)
+    await download(job.source, path.join(solutionDir, 'solution'))
+  }
+
+  run(currentJobDir: string, job: ProjectJob) {
+    const LANG_CONFIG = config.LANGS[job.lang]
+    return exec(`docker run \\
+        --cpus="${LANG_CONFIG.CPU_SHARE}" \\
+        --memory="${LANG_CONFIG.MEM_LIMIT}" \\
+        --rm \\
+        -v "${currentJobDir}":/usr/src/runbox \\
+        -w /usr/src/runbox codingblocks/project-worker-"${job.lang}" \\
+        /bin/judge.sh -s "${job.submissionDirs}"
+    `)
   }
 
   async result(currentJobDir: string, job: ProjectJob): Promise<ProjectResult> {

--- a/src/tasks/scenarios/project.ts
+++ b/src/tasks/scenarios/project.ts
@@ -1,6 +1,6 @@
 import config = require('../../../config.js')
-import {cat, exec, mkdir, rm, touch, head} from 'shelljs'
-import {ProjectJob} from 'tasks/job'
+import { cat, exec, mkdir, rm, touch, head } from 'shelljs'
+import { ProjectJob } from '../jobs/project'
 import { ProjectResult } from 'types/result'
 import * as path from 'path'
 import { Scenario } from 'tasks/scenario'

--- a/src/tasks/scenarios/project.ts
+++ b/src/tasks/scenarios/project.ts
@@ -25,7 +25,7 @@ export default class ProjectScenario extends Scenario {
 
   run(currentJobDir: string, job: ProjectJob) {
 
-    // LANG_CONFIG is undefined rn
+    // LANG_CONFIG is undefined rn, hence card coding the value of cpus and memory
     const LANG_CONFIG = config.LANGS[job.lang]
     return exec(`docker run \\
         --cpus="1" \\
@@ -33,7 +33,7 @@ export default class ProjectScenario extends Scenario {
         --rm \\
         -v "${currentJobDir}":/usr/src/runbox \\
         -w /usr/src/runbox codingblocks/project-worker-"${job.lang}" \\
-        /bin/judge.sh -s "${job.submissionDirs}
+        /bin/judge.sh -s "${job.submissionDirs}"
     `);
   }
 
@@ -53,12 +53,10 @@ export default class ProjectScenario extends Scenario {
     }
 
     const build_stderr = cat(path.join(currentJobDir, 'build.stderr')).toString()
-    const stderr = build_stderr || cat((path.join(currentJobDir, 'run.stderr')).toString())
-
-    if (stderr) {
+    if (build_stderr) {
       return {
         id: job.id,
-        stderr,
+        stderr: build_stderr,
         stdout: '',
         code: 12123,
         time: 1,
@@ -66,15 +64,16 @@ export default class ProjectScenario extends Scenario {
       }
     }
 
-    const build_stdout = cat(path.join(currentJobDir, 'build.stdout')).toString()
-    const stdout = build_stdout || cat(path.join(currentJobDir, 'run.stdout')).toString()
+    const stderr = cat((path.join(currentJobDir, 'run.stderr')).toString())
+    const run_stdout = cat(path.join(currentJobDir, 'run.stdout')).toString()
 
+    // if code is set to 0, change the condition in judge-api queue logic
     return {
       id: job.id,
-      stderr: '',
-      stdout: stdout,
+      stderr: stderr,
+      stdout: run_stdout,
       time: 0,
-      code: 10,
+      code: 100,
       score: 100
     }
   }

--- a/src/tasks/scenarios/project.ts
+++ b/src/tasks/scenarios/project.ts
@@ -1,5 +1,5 @@
 import config = require('../../../config.js')
-import { cat, exec, mkdir, rm, touch, head } from 'shelljs'
+import { cat, exec, mkdir} from 'shelljs'
 import { ProjectJob } from '../jobs/project'
 import { ProjectResult } from 'types/result'
 import * as path from 'path'
@@ -35,24 +35,21 @@ export default class ProjectScenario extends Scenario {
   }
 
   async result(currentJobDir: string, job: ProjectJob): Promise<ProjectResult> {
-    let result_code = cat(path.join(currentJobDir, 'result.code')).toString()
-    if (result_code) {
-      //problem hash and solution hash were not equal
-      return {
-        id: job.id,
-        stderr: cat(path.join(currentJobDir, 'result.stderr')).toString(),
-        stdout: '',
-        code: parseInt(result_code),
-        time: 0,
-        score: 0
-      }
+    const result_code = cat(path.join(currentJobDir, 'result.code')).toString()
+    if (result_code === '25') {
+        //problem hash and solution hash were not equal
+        return {
+          id: job.id,
+          stderr: cat(path.join(currentJobDir, 'result.stderr')).toString(),
+          stdout: '',
+          code: parseInt(result_code),
+          time: 0,
+          score: 0
+        }
     }
 
-    // if hashes were equal, result_code will be found inside solution directory
-    const solutionDir = path.join(currentJobDir, 'solution')
-    result_code = cat(path.join(solutionDir, 'result.code')).toString()
-    const result_time = cat(path.join(solutionDir, 'result.time')).toString()
     const build_stderr = cat(path.join(currentJobDir, 'build.stderr')).toString()
+    const result_time = cat(path.join(currentJobDir, 'result.time').toString()) || '0'
 
     if (build_stderr) {
       return {

--- a/src/tasks/scenarios/project.ts
+++ b/src/tasks/scenarios/project.ts
@@ -8,6 +8,7 @@ import { download } from 'utils/request'
 
 export default class ProjectScenario extends Scenario {
   async setup(currentJobDir: string, job: ProjectJob) {
+    // check this. directory might be wrong
     const problemDir = path.join(currentJobDir, 'problem')
     mkdir('-p', problemDir)
     await download(job.problem, path.join(problemDir, 'problem'))
@@ -26,16 +27,46 @@ export default class ProjectScenario extends Scenario {
         -v "${currentJobDir}":/usr/src/runbox \\
         -w /usr/src/runbox codingblocks/project-worker-"${job.lang}" \\
         /bin/judge.sh -s "${job.submissionDirs}"
-    `)
+    `);
   }
 
   async result(currentJobDir: string, job: ProjectJob): Promise<ProjectResult> {
-    // TODO
+
+    const result_code = cat(path.join(currentJobDir, 'result.code')).toString()
+
+    if (result_code) {
+      // problem hash and solution hash were not equal. // error
+      return {
+        id: job.id,
+        stderr: cat(path.join(currentJobDir, 'result.stderr')).toString(),
+        stdout: '',
+        code: parseInt(result_code),
+        time: 1,
+        score: 0
+      }
+    }
+
+    const build_stderr = cat(path.join(currentJobDir, 'build.stderr')).toString()
+    const stderr = build_stderr || cat((path.join(currentJobDir, 'run.stderr')).toString())
+
+    if (stderr) {
+      return {
+        id: job.id,
+        stderr: build_stderr,
+        stdout: '',
+        code: 12123,
+        time: 1,
+        score: 0
+      }
+    }
+
+    const build_stdout = cat(path.join(currentJobDir, 'build.stdout')).toString()
+    const stdout = build_stdout || cat(path.join(currentJobDir, 'run.stdout')).toString()
 
     return {
       id: job.id,
       stderr: '',
-      stdout: '',
+      stdout: stdout,
       time: 0,
       code: 0,
       score: 0

--- a/src/tasks/scenarios/run.ts
+++ b/src/tasks/scenarios/run.ts
@@ -1,6 +1,6 @@
 import config = require('../../../config.js')
-import {cat, exec, mkdir, rm, touch, head} from 'shelljs'
-import { RunJob } from '../job'
+import { cat, exec, mkdir, rm, touch, head } from 'shelljs'
+import { RunJob} from '../jobs/run'
 import { RunResult } from 'types/result'
 import * as path from 'path'
 import * as fs from 'fs'

--- a/src/tasks/scenarios/submission.ts
+++ b/src/tasks/scenarios/submission.ts
@@ -1,6 +1,6 @@
 import config = require('../../../config.js')
 import { cat, ls, mkdir, exec } from 'shelljs'
-import { SubmitJob } from 'tasks/job'
+import { SubmitJob } from '../jobs/submission'
 import { SubmissionResult } from 'types/result'
 import * as path from 'path'
 import * as fs from 'fs'

--- a/test/run/run.c.spec.ts
+++ b/test/run/run.c.spec.ts
@@ -1,6 +1,7 @@
 import {execute} from '../../src/tasks/'
 import {expect} from 'chai'
-import { RunJob } from '../../src/tasks/job'
+import {RunJob} from '../../src/tasks/jobs/run'
+
 describe('run - c', () => {
   it('.c file runs correctly', async () => {
     const runResult = await execute(new RunJob({

--- a/test/run/run.cpp.spec.ts
+++ b/test/run/run.cpp.spec.ts
@@ -1,6 +1,7 @@
 import {execute} from '../../src/tasks/'
 import {expect} from 'chai'
-import { RunJob } from '../../src/tasks/job'
+import {RunJob} from '../../src/tasks/jobs/run'
+
 
 describe('run - cpp', () => {
   it('.cpp file runs correctly', async () => {

--- a/test/run/run.csharp.spec.ts
+++ b/test/run/run.csharp.spec.ts
@@ -1,6 +1,7 @@
 import {execute} from '../../src/tasks/'
 import {expect} from 'chai'
-import { RunJob } from '../../src/tasks/job'
+import {RunJob} from '../../src/tasks/jobs/run'
+
 
 describe('run - csharp', () => {
   it('.cs file runs correctly', async () => {

--- a/test/run/run.java8.spec.ts
+++ b/test/run/run.java8.spec.ts
@@ -1,6 +1,7 @@
 import {execute} from '../../src/tasks/'
 import {expect} from 'chai'
-import { RunJob } from '../../src/tasks/job'
+import {RunJob} from '../../src/tasks/jobs/run'
+
 
 describe('run - java8', () => {
   it('.java file runs correctly (Java8)', async () => {

--- a/test/run/run.nodejs10.spec.ts
+++ b/test/run/run.nodejs10.spec.ts
@@ -1,6 +1,7 @@
 import {execute} from '../../src/tasks/'
 import {expect} from 'chai'
-import { RunJob } from '../../src/tasks/job'
+import {RunJob} from '../../src/tasks/jobs/run'
+
 describe('run - nodejs10', () => {
   it('.js file runs correctly (NodeJS 6)', async () => {
     const runResult = await execute(new RunJob({

--- a/test/run/run.nodejs8.spec.ts
+++ b/test/run/run.nodejs8.spec.ts
@@ -1,6 +1,7 @@
 import {execute} from '../../src/tasks/'
 import {expect} from 'chai'
-import { RunJob } from '../../src/tasks/job'
+import {RunJob} from '../../src/tasks/jobs/run'
+
 
 describe('run - nodejs8', () => {
   it('.js file runs correctly (NodeJS 8)', async () => {

--- a/test/run/run.py2.spec.ts
+++ b/test/run/run.py2.spec.ts
@@ -1,6 +1,7 @@
 import {execute} from '../../src/tasks/'
 import {expect} from 'chai'
-import { RunJob } from '../../src/tasks/job'
+import {RunJob} from '../../src/tasks/jobs/run'
+
 
 describe('run - py2', () => {
   it('.py file runs correctly (Python 2.7)', async () => {

--- a/test/run/run.py3.spec.ts
+++ b/test/run/run.py3.spec.ts
@@ -1,6 +1,7 @@
 import {execute} from '../../src/tasks/'
 import {expect} from 'chai'
-import { RunJob } from '../../src/tasks/job'
+import {RunJob} from '../../src/tasks/jobs/run'
+
 
 describe('run - py3', () => {
   it('.py file runs correctly (Python 3.0)', async () => {

--- a/test/run/run.ruby.spec.ts
+++ b/test/run/run.ruby.spec.ts
@@ -1,6 +1,7 @@
 import {execute} from '../../src/tasks/'
 import {expect} from 'chai'
-import { RunJob } from '../../src/tasks/job'
+import {RunJob} from '../../src/tasks/jobs/run'
+
 
 describe('run - ruby', () => {
   it('.rb file runs correctly', async () => {

--- a/test/scenarios/projectScenario.spec.ts
+++ b/test/scenarios/projectScenario.spec.ts
@@ -1,16 +1,16 @@
 import { expect } from 'chai'
-import { ProjectJob } from '../../src/tasks/job'
+import { ProjectJob } from '../../src/tasks/jobs/project';
 import ProjectScenarion from '../../src/tasks/scenarios/project'
 
 describe('Project Scenario', () => {
   it('should setup', async () => {
-    const job: ProjectJob = {
-      id: 1,
-      source: '',
-      lang: 'nodejs',
-      timelimit: 20,
-      scenario: 'problem',
-      problem: ''
-    }
+    // const job: ProjectJob = {
+    //   id: 1,
+    //   source: '',
+    //   lang: 'nodejs',
+    //   timelimit: 20,
+    //   scenario: 'problem',
+    //   problem: ''
+    // }
   })
 })

--- a/test/scenarios/runScenario.spec.ts
+++ b/test/scenarios/runScenario.spec.ts
@@ -3,7 +3,7 @@ import { mkdir, rm } from 'shelljs'
 import RunScenario from '../../src/tasks/scenarios/run'
 import config = require('../../config.js')
 import * as path from 'path'
-import { RunJob } from '../../src/tasks/job'
+import {RunJob} from '../../src/tasks/jobs/run'
 import * as fs from 'fs'
 
 describe('Run Scenario', () => {

--- a/test/scenarios/submissionScenario.spec.ts
+++ b/test/scenarios/submissionScenario.spec.ts
@@ -4,7 +4,7 @@ import { mkdir, rm } from 'shelljs'
 import config = require('../../config.js')
 import * as path from 'path'
 import SubmissionScenario from '../../src/tasks/scenarios/submission'
-import { SubmitJob } from '../../src/tasks/job'
+import { SubmitJob } from '../../src/tasks/jobs/submission'
 
 describe('Submission Scenario', () => {
   it('should setup', async () => {

--- a/test/submission/submit.c.spec.ts
+++ b/test/submission/submit.c.spec.ts
@@ -1,6 +1,6 @@
 import { execute } from '../../src/tasks/'
 import { expect } from 'chai'
-import { SubmitJob } from '../../src/tasks/job'
+import { SubmitJob } from "../../src/tasks/jobs/submission"
 import { SubmissionResult } from '../../src/types/result'
 
 describe('submit - c', () => {

--- a/test/submission/submit.cpp.spec.ts
+++ b/test/submission/submit.cpp.spec.ts
@@ -1,6 +1,6 @@
 import { execute } from '../../src/tasks/'
 import { expect } from 'chai'
-import { SubmitJob } from '../../src/tasks/job'
+import { SubmitJob } from "../../src/tasks/jobs/submission"
 import { SubmissionResult } from '../../src/types/result'
 
 describe('submit - cpp', () => {

--- a/test/submission/submit.csharp.spec.ts
+++ b/test/submission/submit.csharp.spec.ts
@@ -1,6 +1,6 @@
 import { execute } from '../../src/tasks/'
 import { expect } from 'chai'
-import { SubmitJob } from '../../src/tasks/job'
+import { SubmitJob } from "../../src/tasks/jobs/submission"
 import { SubmissionResult } from '../../src/types/result'
 
 describe('submit - csharp', () => {

--- a/test/submission/submit.java8.spec.ts
+++ b/test/submission/submit.java8.spec.ts
@@ -1,6 +1,6 @@
 import { execute } from '../../src/tasks/'
 import { expect } from 'chai'
-import { SubmitJob } from '../../src/tasks/job'
+import { SubmitJob } from "../../src/tasks/jobs/submission"
 import { SubmissionResult } from '../../src/types/result'
 
 describe('submit - java8', () => {

--- a/test/submission/submit.nodejs10.spec.ts
+++ b/test/submission/submit.nodejs10.spec.ts
@@ -1,6 +1,6 @@
 import { execute } from '../../src/tasks/'
 import { expect } from 'chai'
-import { SubmitJob } from '../../src/tasks/job'
+import { SubmitJob } from "../../src/tasks/jobs/submission"
 import { SubmissionResult } from '../../src/types/result'
 
 describe('submit - nodejs10', () => {

--- a/test/submission/submit.nodejs8.spec.ts
+++ b/test/submission/submit.nodejs8.spec.ts
@@ -1,6 +1,6 @@
 import { execute } from '../../src/tasks/'
 import { expect } from 'chai'
-import { SubmitJob } from '../../src/tasks/job'
+import { SubmitJob } from "../../src/tasks/jobs/submission"
 import { SubmissionResult } from '../../src/types/result'
 
 describe('submit - nodejs8', () => {

--- a/test/submission/submit.py2.spec.ts
+++ b/test/submission/submit.py2.spec.ts
@@ -1,6 +1,6 @@
 import { execute } from '../../src/tasks/'
 import { expect } from 'chai'
-import { SubmitJob } from '../../src/tasks/job'
+import { SubmitJob } from "../../src/tasks/jobs/submission"
 import { SubmissionResult } from '../../src/types/result'
 
 describe('submit - py2', () => {

--- a/test/submission/submit.py3.spec.ts
+++ b/test/submission/submit.py3.spec.ts
@@ -1,6 +1,6 @@
 import { execute } from '../../src/tasks/'
 import { expect } from 'chai'
-import { SubmitJob } from '../../src/tasks/job'
+import { SubmitJob } from "../../src/tasks/jobs/submission"
 import { SubmissionResult } from '../../src/types/result'
 
 describe('submit - py3', () => {

--- a/test/submission/submit.ruby.spec.ts
+++ b/test/submission/submit.ruby.spec.ts
@@ -1,6 +1,6 @@
 import { execute } from '../../src/tasks/'
 import { expect } from 'chai'
-import { SubmitJob } from '../../src/tasks/job'
+import { SubmitJob } from "../../src/tasks/jobs/submission"
 import { SubmissionResult } from '../../src/types/result'
 
 describe('submit - ruby', () => {


### PR DESCRIPTION
fixes #36, #39 


- [x] Create project scenario

  - [x]   Complete setup method ( as done here in the test)
  - [x]   Complete run method
    - [x] Complete result method
    - [ ] Write tests for the methods and scenario


- [x] Send the payload to the job

- [x] Refactor src/tasks/job.ts

    - [x] Create src/tasks/jobs/ directory
   - [x] Move all the jobs other than Base class to individual files in jobs dir
   - [x]  Like move RunJob and its type to src/tasks/jobs/run.ts
    - [x] Refactor imports to support current structure
